### PR TITLE
feat: extractArgv refactor & extract debug port

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,3 +25,4 @@ exports.CovCommand = require('./lib/cmd/cov');
 exports.DevCommand = require('./lib/cmd/dev');
 exports.TestCommand = require('./lib/cmd/test');
 exports.DebugCommand = require('./lib/cmd/debug');
+exports.PkgfilesCommand = require('./lib/cmd/pkgfiles');

--- a/lib/cmd/cov.js
+++ b/lib/cmd/cov.js
@@ -34,7 +34,8 @@ class CovCommand extends Command {
     return 'Run test with coverage';
   }
 
-  * run({ cwd, argv, execArgv }) {
+  * run(context) {
+    const { cwd, argv, execArgv } = context;
     const tmpDir = path.join(cwd, '.tmp');
     yield mkdirp(tmpDir);
 
@@ -61,7 +62,7 @@ class CovCommand extends Command {
     };
 
     // save coverage-xxxx.json to $PWD/coverage
-    const covArgs = this.getCovArgs(argv);
+    const covArgs = this.getCovArgs(context);
     debug('covArgs: %j', covArgs);
     yield this.helper.forkNode(covFile, covArgs, opt);
     yield rimraf(tmpDir);
@@ -81,11 +82,11 @@ class CovCommand extends Command {
 
   /**
    * get coverage args
-   * @param {Object} argv - use to extract test args
+   * @param {Object} context - { cwd, argv, ...}
    * @return {Array} args for istanbul
    * @protected
    */
-  getCovArgs(argv) {
+  getCovArgs(context) {
     const covArgs = [
       'cover',
       '--report', 'none',
@@ -98,7 +99,7 @@ class CovCommand extends Command {
       covArgs.push(exclude);
     }
     const mochaFile = require.resolve('mocha/bin/_mocha');
-    const testArgs = this.formatTestArgs(argv);
+    const testArgs = this.formatTestArgs(context);
     debug('testArgs: %j', testArgs);
     return covArgs.concat(mochaFile, '--', ...testArgs);
   }

--- a/lib/cmd/pkgfiles.js
+++ b/lib/cmd/pkgfiles.js
@@ -3,6 +3,11 @@
 const Command = require('../command');
 
 class PkgfilesCommand extends Command {
+  constructor(rawArgv) {
+    super(rawArgv);
+    this.usage = 'Usage: egg-bin pkgfiles';
+  }
+
   get description() {
     return 'Generate pkg.files automatically';
   }

--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -33,33 +33,39 @@ class TestCommand extends Command {
     return 'Run test with mocha';
   }
 
-  * run({ argv, execArgv }) {
+  * run(context) {
     process.env.NODE_ENV = 'test';
-    const newArgs = this.formatTestArgs(argv);
+    const testArgs = this.formatTestArgs(context);
     const opt = {
       env: Object.assign({}, process.env),
-      execArgv,
+      execArgv: context.execArgv,
     };
     const mochaFile = require.resolve('mocha/bin/_mocha');
-    debug('run test: %s %s', mochaFile, newArgs.join(' '));
-    yield this.helper.forkNode(mochaFile, newArgs, opt);
+    debug('run test: %s %s', mochaFile, testArgs.join(' '));
+    yield this.helper.forkNode(mochaFile, testArgs, opt);
   }
 
   /**
    * format test args then change it to array style
-   * @method helper#formatTestArgs
-   * @param {Object} argv - yargs style
+   * @param {Object} context - { cwd, argv, ...}
    * @return {Array} [ '--require=xxx', 'xx.test.js' ]
+   * @protected
    */
-  formatTestArgs(argv) {
-    const newArgv = Object.assign({}, argv);
+  formatTestArgs({ argv, debug }) {
+    const testArgv = Object.assign({}, argv);
 
     /* istanbul ignore next */
-    newArgv.timeout = newArgv.timeout || process.env.TEST_TIMEOUT || '30000';
-    newArgv.reporter = newArgv.reporter || process.env.TEST_REPORTER;
+    testArgv.timeout = testArgv.timeout || process.env.TEST_TIMEOUT || 30000;
+    testArgv.reporter = testArgv.reporter || process.env.TEST_REPORTER;
+
+    if (debug) {
+      // --no-timeouts
+      testArgv.timeouts = false;
+      testArgv.timeout = undefined;
+    }
 
     // collect require
-    let requireArr = newArgv.require || newArgv.r || [];
+    let requireArr = testArgv.require || testArgv.r || [];
     /* istanbul ignore next */
     if (!Array.isArray(requireArr)) requireArr = [ requireArr ];
 
@@ -71,10 +77,10 @@ class TestCommand extends Command {
       requireArr.push(require.resolve('intelli-espower-loader'));
     }
 
-    newArgv.require = requireArr;
+    testArgv.require = requireArr;
 
     // collect test files
-    let files = newArgv._.slice();
+    let files = testArgv._.slice();
     if (!files.length) {
       files = [ process.env.TESTS || 'test/**/*.test.js' ];
     }
@@ -86,15 +92,15 @@ class TestCommand extends Command {
     if (fs.existsSync(setupFile)) {
       files.unshift(setupFile);
     }
-    newArgv._ = files;
+    testArgv._ = files;
 
     // remove alias
-    newArgv.$0 = undefined;
-    newArgv.r = undefined;
-    newArgv.t = undefined;
-    newArgv.g = undefined;
+    testArgv.$0 = undefined;
+    testArgv.r = undefined;
+    testArgv.t = undefined;
+    testArgv.g = undefined;
 
-    return this.helper.unparseArgv(newArgv);
+    return this.helper.unparseArgv(testArgv);
   }
 }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -15,7 +15,7 @@ class Command extends BaseCommand {
 
     // extract execArgv to special item
     context.execArgv = this.helper.unparseArgv(argv, {
-      includes: [ 'debug', 'debug-brk', 'inspect', 'inspect-brk', 'es_staging', /^harmony.*/ ],
+      includes: [ 'debug', 'debug-brk', 'inspect', 'inspect-brk', 'es_staging', 'expose_debug_as', /^harmony.*/ ],
     });
 
     // remove unuse args

--- a/lib/command.js
+++ b/lib/command.js
@@ -14,18 +14,37 @@ class Command extends BaseCommand {
     const argv = context.argv;
 
     // extract execArgv to special item
-    context.execArgv = this.helper.unparseArgv(argv, {
-      includes: [ 'debug', 'debug-brk', 'inspect', 'inspect-brk', 'es_staging', 'expose_debug_as', /^harmony.*/ ],
-    });
+    const execArgvObj = {};
+    let debugPort;
+    const match = (key, arr) => arr.some(x => x instanceof RegExp ? x.test(key) : x === key); // eslint-disable-line no-confusing-arrow
+    for (const key of Object.keys(argv)) {
+      let isMatch = false;
+
+      // debug / debug-brk / debug-port / inspect / inspect-brk / inspect-port
+      if (match(key, [ /^debug.*/, /^inspect.*/ ])) {
+        isMatch = true;
+        // extract debug port
+        if (debugPort === undefined || typeof argv[key] === 'number') {
+          debugPort = argv[key];
+        }
+      } else if (match(key, [ 'es_staging', 'expose_debug_as', /^harmony.*/ ])) {
+        isMatch = true;
+      }
+
+      if (isMatch) {
+        execArgvObj[key] = argv[key];
+        argv[key] = undefined;
+        // also remove `debugBrk`
+        argv[changeCase.camelCase(key)] = undefined;
+      }
+    }
+
+    context.execArgv = this.helper.unparseArgv(execArgvObj);
+    context.execArgvObj = execArgvObj;
+    context.debug = debugPort;
 
     // remove unuse args
     argv.$0 = undefined;
-    for (const item of context.execArgv) {
-      // --debug=7000 => debug
-      const key = item.replace(/--([^=]*)=?.*/, '$1');
-      argv[key] = undefined;
-      argv[changeCase.camelCase(key)] = undefined;
-    }
 
     return context;
   }

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "node": ">= 6.0.0"
   },
   "files": [
-    "bin",
+    "index.js",
     "lib",
-    "index.js"
+    "bin"
   ],
   "ci": {
     "version": "6, 7"

--- a/test/fixtures/my-egg-bin/lib/cmd/test-debug.js
+++ b/test/fixtures/my-egg-bin/lib/cmd/test-debug.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Command = require('../../../../../').TestCommand;
+
+class TestDebugCommand extends Command {
+  get description() {
+    return 'test';
+  }
+
+  * run(context) {
+    const testArgs = this.formatTestArgs(context);
+    console.log('%j', testArgs);
+  }
+}
+
+module.exports = TestDebugCommand;

--- a/test/lib/cmd/debug.test.js
+++ b/test/lib/cmd/debug.test.js
@@ -13,8 +13,8 @@ describe('test/lib/cmd/debug.test.js', () => {
 
   it('should startCluster success', done => {
     coffee.fork(eggBin, [ 'debug' ], { cwd })
-      // .debug()
       .expect('stderr', /Debugger listening/)
+      .expect('stderr', /chrome-devtools:/)
       .expect('stdout', /"workers":1/)
       .expect('code', 0)
       .end(done);

--- a/test/my-egg-bin.test.js
+++ b/test/my-egg-bin.test.js
@@ -58,7 +58,7 @@ describe('test/my-egg-bin.test.js', () => {
     const args = [
       'echo',
       '--baseDir=./dist',
-      '--debug=5555', '--debug-brk',
+      '--debug', '--debug-brk=5555',
       '--expose_debug_as=v8debug',
       '--inspect', '6666', '--inspect-brk',
       '--es_staging', '--harmony', '--harmony_default_parameters',
@@ -66,8 +66,25 @@ describe('test/my-egg-bin.test.js', () => {
     coffee.fork(eggBin, args, { cwd })
       // .debug()
       .expect('stdout', /"baseDir":".\/dist"/)
+      .expect('stdout', /"debug":6666/)
       .notExpect('stdout', /"debugBrk":true/)
-      .expect('stdout', /"execArgv":\["--debug=5555","--debug-brk","--expose_debug_as=v8debug","--inspect=6666","--inspect-brk","--es_staging","--harmony","--harmony_default_parameters"]/)
+      .expect('stdout', /"execArgv":\["--debug","--debug-brk=5555","--expose_debug_as=v8debug","--inspect=6666","--inspect-brk","--es_staging","--harmony","--harmony_default_parameters"]/)
+      .expect('code', 0)
+      .end(done);
+  });
+
+  it('should add no-timeouts at test when debug enabled', done => {
+    const args = [
+      'test-debug',
+      '--baseDir=./dist',
+      '--debug', '--debug-brk=5555',
+      '--expose_debug_as=v8debug',
+      '--inspect', '6666', '--inspect-brk',
+    ];
+    coffee.fork(eggBin, args, { cwd })
+      // .debug()
+      .expect('stdout', /"--no-timeouts",/)
+      .notExpect('stdout', /"--timeout=/)
       .expect('code', 0)
       .end(done);
   });

--- a/test/my-egg-bin.test.js
+++ b/test/my-egg-bin.test.js
@@ -59,6 +59,7 @@ describe('test/my-egg-bin.test.js', () => {
       'echo',
       '--baseDir=./dist',
       '--debug=5555', '--debug-brk',
+      '--expose_debug_as=v8debug',
       '--inspect', '6666', '--inspect-brk',
       '--es_staging', '--harmony', '--harmony_default_parameters',
     ];
@@ -66,7 +67,7 @@ describe('test/my-egg-bin.test.js', () => {
       // .debug()
       .expect('stdout', /"baseDir":".\/dist"/)
       .notExpect('stdout', /"debugBrk":true/)
-      .expect('stdout', /"execArgv":\["--debug=5555","--debug-brk","--inspect=6666","--inspect-brk","--es_staging","--harmony","--harmony_default_parameters"]/)
+      .expect('stdout', /"execArgv":\["--debug=5555","--debug-brk","--expose_debug_as=v8debug","--inspect=6666","--inspect-brk","--es_staging","--harmony","--harmony_default_parameters"]/)
       .expect('code', 0)
       .end(done);
   });


### PR DESCRIPTION
- extract `extractArgvObj` to `context`
- if `debug / debug-brk / debug-port / inspect / inspect-brk / inspect-port` then `context.debug` will set to debug port.
- if `debug`, will pass `--no-timeouts` to mocha