### PR TITLE
fix: use inspector at 7.x+

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ egg-bin dev
 
 Debug egg app with [V8 Inspector Integration](https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js).
 
-automatically detect the protocol used by the targeted runtime, 8.0+ the new 'inspector' protocol is used.
+automatically detect the protocol, use the new `inspector` when the targeted runtime >=7.0.0 .
 
 use [inspector-proxy](https://github.com/whxaxes/inspector-proxy) to proxy worker debug, so you don't need to worry about reload.
 

--- a/lib/cmd/debug.js
+++ b/lib/cmd/debug.js
@@ -6,7 +6,7 @@ const InspectorProxy = require('inspector-proxy');
 const debug = require('debug')('egg-bin');
 const semver = require('semver');
 const Command = require('./dev');
-const newDebugger = semver.gte(process.version, '8.0.0');
+const newDebugger = semver.gte(process.version, '7.0.0');
 
 class DebugCommand extends Command {
   constructor(rawArgv) {

--- a/test/lib/cmd/debug.test.js
+++ b/test/lib/cmd/debug.test.js
@@ -66,7 +66,7 @@ describe('test/lib/cmd/debug.test.js', () => {
 
   describe('real egg', () => {
     const cwd = path.join(__dirname, '../../fixtures/example');
-    const newDebugger = semver.gte(process.version, '8.0.0');
+    const newDebugger = semver.gte(process.version, '7.0.0');
 
     it('should proxy', function* () {
       const app = coffee.fork(eggBin, [ 'debug' ], { cwd });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

`process.debugPort` is correct at 7.0.0, so adjust debug protocol.
https://github.com/nodejs/node/pull/8386/files