### PR TITLE
fix: force exit when runner complete

### DIFF
--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -59,6 +59,8 @@ class TestCommand extends Command {
     /* istanbul ignore next */
     testArgv.timeout = testArgv.timeout || process.env.TEST_TIMEOUT || 60000;
     testArgv.reporter = testArgv.reporter || process.env.TEST_REPORTER;
+    // force exit
+    testArgv.exit = true;
 
     if (debug) {
       // --no-timeouts

--- a/test/fixtures/no-exit/test/foo.test.js
+++ b/test/fixtures/no-exit/test/foo.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const http = require('http');
+const assert = require('assert');
+
+describe('mocha-test', () => {
+  it('should work', () => {
+    assert(true);
+  });
+});
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('okay');
+});
+server.listen();

--- a/test/lib/cmd/test.test.js
+++ b/test/lib/cmd/test.test.js
@@ -110,7 +110,7 @@ describe('test/lib/cmd/test.test.js', () => {
       .end();
   });
 
-  it.only('should force exit', () => {
+  it('should force exit', () => {
     const cwd = path.join(__dirname, '../../fixtures/no-exit');
     return coffee.fork(eggBin, [ 'test' ], { cwd })
       .debug()

--- a/test/lib/cmd/test.test.js
+++ b/test/lib/cmd/test.test.js
@@ -110,6 +110,14 @@ describe('test/lib/cmd/test.test.js', () => {
       .end();
   });
 
+  it.only('should force exit', () => {
+    const cwd = path.join(__dirname, '../../fixtures/no-exit');
+    return coffee.fork(eggBin, [ 'test' ], { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+  });
+
   describe('simplify mocha error stack', () => {
     const cwd = path.join(__dirname, '../../fixtures/test-files-stack');
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

mocha4 changed the default behavior when runner complete

