### PR TITLE
fix: fixed ts-node ignore files

### DIFF
--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -2,4 +2,5 @@
 
 require('ts-node').register({
   typeCheck: true,
+  files: true,
 });

--- a/test/fixtures/example-ts/app/controller/home.ts
+++ b/test/fixtures/example-ts/app/controller/home.ts
@@ -4,6 +4,8 @@ import { Controller } from 'egg';
 
 export default class HomeController extends Controller {
   public async index() {
-    this.ctx.body = 'hi, egg';
+    const obj: PlainObject = {};
+    obj.text = 'hi, egg';
+    this.ctx.body = obj.text;
   }
 }

--- a/test/fixtures/example-ts/typings/global.d.ts
+++ b/test/fixtures/example-ts/typings/global.d.ts
@@ -1,0 +1,3 @@
+interface PlainObject extends Object {
+  [key: string]: any;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

ts-node 7.0 默认忽略了 files 入参，即会导致 ts 不会自动加载项目目录下的 d.ts ，只会通过 import 来加载对应模块的 d.ts。而 egg 的声明合并模式需要自动加载 d.ts ，因此加上 files 入参。

https://github.com/TypeStrong/ts-node#help-my-types-are-missing