### PR TITLE
feat: upgrade espower-typescript to 9.0

### DIFF
--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -103,6 +103,7 @@ class TestCommand extends Command {
 
     // for power-assert
     if (testArgv.typescript) {
+      // remove ts-node in context getter on top.
       requireArr.push(require.resolve('espower-typescript/guess'));
     }
 

--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -50,6 +50,24 @@ class TestCommand extends Command {
     yield this.helper.forkNode(mochaFile, testArgs, opt);
   }
 
+  get context() {
+    const context = super.context;
+    const { argv, execArgvObj } = context;
+
+    // for power-assert, replace ts-node to espower-typescript
+    // ts-node and espower-typescript can't coexist
+    // because espower-typescript has already register ts-node from 9.0
+    if (argv.typescript) {
+      execArgvObj.require.splice(
+        execArgvObj.require.indexOf(require.resolve('ts-node/register')),
+        1,
+        require.resolve('espower-typescript/guess')
+      );
+    }
+
+    return context;
+  }
+
   /**
    * format test args then change it to array style
    * @param {Object} context - { cwd, argv, ...}
@@ -86,11 +104,6 @@ class TestCommand extends Command {
       console.warn('[egg-bin] don\'t need to manually require `intelli-espower-loader` anymore');
     } else {
       requireArr.push(require.resolve('intelli-espower-loader'));
-    }
-
-    // for power-assert
-    if (testArgv.typescript) {
-      requireArr.push(require.resolve('espower-typescript/guess'));
     }
 
     testArgv.require = requireArr;

--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -54,15 +54,10 @@ class TestCommand extends Command {
     const context = super.context;
     const { argv, execArgvObj } = context;
 
-    // for power-assert, replace ts-node to espower-typescript
-    // ts-node and espower-typescript can't coexist
-    // because espower-typescript has already register ts-node from 9.0
+    // remove ts-node, ts-node and espower-typescript can't coexist
+    // because espower-typescript@9 has already register ts-node
     if (argv.typescript) {
-      execArgvObj.require.splice(
-        execArgvObj.require.indexOf(require.resolve('ts-node/register')),
-        1,
-        require.resolve('espower-typescript/guess')
-      );
+      execArgvObj.require.splice(execArgvObj.require.indexOf(require.resolve('ts-node/register')), 1);
     }
 
     return context;
@@ -104,6 +99,11 @@ class TestCommand extends Command {
       console.warn('[egg-bin] don\'t need to manually require `intelli-espower-loader` anymore');
     } else {
       requireArr.push(require.resolve('intelli-espower-loader'));
+    }
+
+    // for power-assert
+    if (testArgv.typescript) {
+      requireArr.push(require.resolve('espower-typescript/guess'));
     }
 
     testArgv.require = requireArr;

--- a/lib/command.js
+++ b/lib/command.js
@@ -53,13 +53,13 @@ class Command extends BaseCommand {
       execArgvObj.require.push(require.resolve('ts-node/register'));
 
       // tell egg-loader to load ts file
-      env.EGG_TYPESCRIPT = true;
+      env.EGG_TYPESCRIPT = 'true';
 
       // use type check
-      env.TS_NODE_TYPE_CHECK = process.env.TS_NODE_TYPE_CHECK || true;
+      env.TS_NODE_TYPE_CHECK = process.env.TS_NODE_TYPE_CHECK || 'true';
 
       // load files from tsconfig on startup
-      env.TS_NODE_FILES = process.env.TS_NODE_FILES || true;
+      env.TS_NODE_FILES = process.env.TS_NODE_FILES || 'true';
     }
 
     return context;

--- a/lib/command.js
+++ b/lib/command.js
@@ -52,7 +52,7 @@ class Command extends BaseCommand {
       execArgvObj.require = execArgvObj.require || [];
       execArgvObj.require.push(require.resolve('ts-node/register'));
 
-      // tell egg-loader to load ts file
+      // tell egg loader to load ts file
       env.EGG_TYPESCRIPT = 'true';
 
       // use type check

--- a/lib/command.js
+++ b/lib/command.js
@@ -50,8 +50,16 @@ class Command extends BaseCommand {
     // execArgv
     if (argv.typescript) {
       execArgvObj.require = execArgvObj.require || [];
-      execArgvObj.require.push(path.join(__dirname, './ts-helper.js'));
+      execArgvObj.require.push(require.resolve('ts-node/register'));
+
+      // tell egg-loader to load ts file
       env.EGG_TYPESCRIPT = true;
+
+      // use type check
+      env.TS_NODE_TYPE_CHECK = process.env.TS_NODE_TYPE_CHECK || true;
+
+      // load files from tsconfig on startup
+      env.TS_NODE_FILES = process.env.TS_NODE_FILES || true;
     }
 
     return context;

--- a/lib/ts-helper.js
+++ b/lib/ts-helper.js
@@ -1,6 +1,0 @@
-'use strict';
-
-require('ts-node').register({
-  typeCheck: true,
-  files: true,
-});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "^3.1.0",
     "detect-port": "^1.2.3",
     "egg-utils": "^2.4.0",
-    "espower-typescript": "^8.0.0",
+    "espower-typescript": "^9.0.0",
     "globby": "^8.0.1",
     "inspector-proxy": "^1.2.1",
     "intelli-espower-loader": "^1.0.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change

### 修复两个问题

1. 将 espower-typescript 升级到 9.0.0 版本，由于老版本的 espower-typescript 自己进行了 ts 解析而没进行类型检查 ，所以会导致此前跑单测，对代码是不会做类型检查的。而 espower-typescript 9.0 版本改成使用 ts-node 进行解析，所以可以开启类型检查。

2. 之前 4.8.0 版本将 espower-typescript 升级到了 9.0.0 版本，但是由于 espower-typescript 中会 register 一下 ts-node，而本身 egg-bin 也会 register 一下 ts-node，从而导致触发了两次 register，就会导致 ts 被编译成 js 后又会再一次去被编译一次。从而导致爆出类型错误，所以在 4.8.0 的 PR 中又将 espower-typescript 改回了 8.0 版本。该 PR 在升级 espower-typescript 的同时也修复了该问题，因为这个多编译一次的问题是会在当前单测中稳定复现的，所以不需要新增单测。

### 其他修改

由于 ts-node 可能是由 espower-typescript 引入，也可能是由 egg-bin 引入，所以删除 ts-helper.js（ 此前是用来给 ts-node 传相关参数 ），改成使用环境变量来控制 ts-node 的入参，才能保证 espower-typescript 及 egg-bin 的表现一致。
