### PR TITLE
add debug-mode agent port check and set

### DIFF
--- a/lib/cmd/dev.js
+++ b/lib/cmd/dev.js
@@ -12,6 +12,7 @@ class DevCommand extends Command {
     this.usage = 'Usage: egg-bin dev [dir] [options]';
 
     this.defaultPort = 7001;
+    this.defaultAgentPort = 5800;
     this.serverBin = path.join(__dirname, '../start-cluster');
 
     this.options = {
@@ -107,6 +108,25 @@ class DevCommand extends Command {
         console.warn(`[egg-bin] server port ${this.defaultPort} is in use, now using port ${port}\n`);
       }
       debug(`use available port ${port}`);
+
+      // add egg.js agent default port check and set
+      debug('detect available agent port');
+      let agentPort = {};
+      if (process.env.EGG_AGENT_DEBUG_PORT) {
+        agentPort = yield detect(process.env.EGG_AGENT_DEBUG_PORT);
+        if (agentPort !== process.env.EGG_AGENT_DEBUG_PORT) {
+          process.env.EGG_AGENT_DEBUG_PORT = agentPort;
+          console.warn(`[egg-bin] agent env port ${process.env.EGG_AGENT_DEBUG_PORT} is in use, now using port ${agentPort}\n`);
+        }
+        debug(`agent use available port ${port}`);
+      } else {
+        agentPort = yield detect(this.defaultAgentPort);
+        if (agentPort !== this.defaultAgentPort) {
+          process.env.EGG_AGENT_DEBUG_PORT = agentPort;
+          console.warn(`[egg-bin] agent default port ${this.defaultAgentPort} is in use, now using port ${agentPort}\n`);
+        }
+      }
+      debug(`agent use available port ${agentPort}`);
     }
     return [ JSON.stringify(argv) ];
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->


test for pr:

alibaba@alibaba-ThinkPad-X1-Carbon-2nd:/home/alibaba/egg-bin$ npm test

> egg-bin@4.9.0 test /home/alibaba/egg-bin
> npm run lint -- --fix && npm run test-local


> egg-bin@4.9.0 lint /home/alibaba/egg-bin
> eslint . "--fix"


> egg-bin@4.9.0 test-local /home/alibaba/egg-bin
> node bin/egg-bin.js test -t 3600000



  test/egg-bin.test.js
    global options
      ✓ should show version (298ms)
      ✓ should show help (315ms)
      ✓ should show help when command not exists (329ms)

  test/lib/cmd/autod.test.js
    ✓ should autod modify (642ms)
[ERROR] Missing dependencies: ["urllib"]

⚠️  Error: /home/alibaba/egg-bin/node_modules/autod/bin/autod.js --check exit with code 1
⚠️  Command Error, enable `DEBUG=common-bin` for detail
    ✓ should autod check fail (462ms)
    ✓ should autod check pass (434ms)

  test/lib/cmd/cov.test.js
    1) should success
    ✓ should exit when not test files (324ms)
    2) should hotfixSpawnWrap success on mock windows
    ✓ should success with COV_EXCLUDES (1028ms)
    ✓ should success with -x to ignore one dirs (1022ms)
    ✓ should success with -x to ignore multi dirs (1020ms)
    ✓ should fail when test fail (921ms)
    ✓ should fail when test fail with power-assert (1000ms)
    ✓ should warn when require intelli-espower-loader (995ms)
    ✓ should run cov when no test files (325ms)
    ✓ should set EGG_BIN_PREREQUIRE (2319ms)
    ✓ should passthrough nyc args (969ms)

  test/lib/cmd/debug.test.js
    ✓ should startCluster success (3411ms)
    ✓ should startCluster with port (3397ms)
    ✓ should debug with $NODE_DEBUG_OPTION (3416ms)
    auto detect available port
      ✓ should auto detect available port (3407ms)
    real egg
      3) should proxy
      4) should proxy with port
      ✓ should not print devtools at vscode (1065ms)
      ✓ should not print devtools at webstorm (1088ms)

  test/lib/cmd/dev.test.js
    ✓ should startCluster success (3406ms)
    ✓ should dev start with custom NODE_ENV (3391ms)
    ✓ should startCluster with --harmony success (3390ms)
    ✓ should startCluster with --port (3373ms)
    ✓ should startCluster with --sticky (3376ms)
    ✓ should startCluster with -p (3370ms)
    ✓ should startCluster with --cluster=2 (3391ms)
    ✓ should startCluster with --baseDir=root (3403ms)
    ✓ should startCluster with custom yadan framework (390ms)
    ✓ should startCluster with execArgv --inspect (3411ms)
    ✓ should support --require (3414ms)
    auto detect available port
      ✓ should auto detect available port (3408ms)

  test/lib/cmd/pkgfiles.test.js
    ✓ should update pkg.files (468ms)
    ✓ should check pkg.files (434ms)

  test/lib/cmd/test.test.js
    ✓ should success (633ms)
    ✓ should ignore node_modules and fixtures (629ms)
    ✓ should only test files specified by TESTS (564ms)
    ✓ should only test files specified by TESTS with multi pattern (563ms)
    ✓ should only test files specified by TESTS argv (564ms)
    ✓ should exit when not test files (320ms)
    ✓ should use process.env.TEST_REPORTER (627ms)
    ✓ should use process.env.TEST_TIMEOUT (634ms)
    ✓ should fail when test fail with power-assert (634ms)
    ✓ should warn when require intelli-espower-loader (633ms)
    ✓ should auto require test/.setup.js (1621ms)


  mocha-test
    ✓ should work


  1 passing (16ms)

    ✓ should force exit (633ms)
    simplify mocha error stack
      ✓ should clean assert error stack (629ms)
      ✓ should should show full stack trace (614ms)
      ✓ should clean co error stack (567ms)
      ✓ should clean callback error stack (579ms)
    changed
No changed test files
      ✓ should return undefined if no test file changed
      ✓ should return file changed
No changed test files
      ✓ should filter not test file

  test/mocha-bin.test.js


  mocha-test
    ✓ should work


  1 passing (6ms)

    ✓ should test with mocha (176ms)

  test/my-egg-bin.test.js
    ✓ should my-egg-bin test success (630ms)
    ✓ should my-egg-bin nsp success (316ms)
    ✓ should my-egg-bin dev success (380ms)
    ✓ should show help message (316ms)
    ✓ should show version 2.3.4 (293ms)
    5) should custom context
    ✓ should add no-timeouts at test when debug enabled (372ms)

  test/ts.test.js
    6) should support ts
    ✓ should support ts test (2103ms)
    real application
      7) should start app
      8) should test app
      9) should cov app
    error stacks
      10) should correct error stack line number in starting app
      ✓ should correct error stack line number in testing app (2010ms)
      ✓ should correct error stack line number in covering app (822ms)
    egg.typescript = true
      11) should start app
      12) should fail start app with --no-ts
      13) should start app with relative path
      14) should test app
