### PR TITLE
add debug-mode agent port check and set

### DIFF
--- a/lib/cmd/dev.js
+++ b/lib/cmd/dev.js
@@ -107,6 +107,25 @@ class DevCommand extends Command {
         console.warn(`[egg-bin] server port ${this.defaultPort} is in use, now using port ${port}\n`);
       }
       debug(`use available port ${port}`);
+      
+      // add egg.js agent default port check and set
+      debug('detect available agent port');
+      let agentPort = {};
+      if (process.env.EGG_AGENT_DEBUG_PORT) {
+        agentPort = yield detect(process.env.EGG_AGENT_DEBUG_PORT);
+        if (agentPort !== process.env.EGG_AGENT_DEBUG_PORT) {
+          process.env.EGG_AGENT_DEBUG_PORT = agentPort;
+          console.warn(`[egg-bin] agent env port ${process.env.EGG_AGENT_DEBUG_PORT} is in use, now using port ${agentPort}\n`);
+        }
+        debug(`agent use available port ${port}`);
+      } else {
+        agentPort = yield detect(this.defaultAgentPort);
+        if (agentPort !== this.defaultAgentPort) {
+          process.env.EGG_AGENT_DEBUG_PORT = agentPort;
+          console.warn(`[egg-bin] agent default port ${this.defaultAgentPort} is in use, now using port ${agentPort}\n`);
+        }
+      }
+      debug(`agent use available port ${agentPort}`);
     }
     return [ JSON.stringify(argv) ];
   }


### PR DESCRIPTION
 add debug-mode agent port check and set

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

test for pr, same as master branch:

alibaba@alibaba-ThinkPad-X1-Carbon-2nd:/home/alibaba/apsara/egg-bin$ npm test

> egg-bin@4.9.0 test /home/alibaba/apsara/egg-bin
> npm run lint -- --fix && npm run test-local


> egg-bin@4.9.0 lint /home/alibaba/apsara/egg-bin
> eslint . "--fix"


> egg-bin@4.9.0 test-local /home/alibaba/apsara/egg-bin
> node bin/egg-bin.js test -t 3600000



  test/egg-bin.test.js
    global options
      ✓ should show version (303ms)
      ✓ should show help (313ms)
      ✓ should show help when command not exists (330ms)

  test/lib/cmd/autod.test.js
    ✓ should autod modify (664ms)
[ERROR] Missing dependencies: ["urllib"]

⚠️  Error: /home/alibaba/apsara/egg-bin/node_modules/autod/bin/autod.js --check exit with code 1
⚠️  Command Error, enable `DEBUG=common-bin` for detail
    ✓ should autod check fail (441ms)
    ✓ should autod check pass (435ms)

  test/lib/cmd/cov.test.js
    ✓ should success (1342ms)
    ✓ should exit when not test files (324ms)
    ✓ should hotfixSpawnWrap success on mock windows (1009ms)
    ✓ should success with COV_EXCLUDES (1026ms)
    ✓ should success with -x to ignore one dirs (1026ms)
    ✓ should success with -x to ignore multi dirs (1029ms)
    ✓ should fail when test fail (928ms)
    ✓ should fail when test fail with power-assert (985ms)
    ✓ should warn when require intelli-espower-loader (988ms)
    ✓ should run cov when no test files (331ms)
    ✓ should set EGG_BIN_PREREQUIRE (2312ms)
    ✓ should passthrough nyc args (947ms)

  test/lib/cmd/debug.test.js
    ✓ should startCluster success (3409ms)
    ✓ should startCluster with port (3393ms)
    ✓ should debug with $NODE_DEBUG_OPTION (3414ms)
    auto detect available port
      ✓ should auto detect available port (3410ms)
    real egg
      1) should proxy
      2) should proxy with port
      ✓ should not print devtools at vscode (1081ms)
      ✓ should not print devtools at webstorm (1082ms)

  test/lib/cmd/dev.test.js
    ✓ should startCluster success (3395ms)
    ✓ should dev start with custom NODE_ENV (3379ms)
    ✓ should startCluster with --harmony success (3404ms)
    ✓ should startCluster with --port (3377ms)
    ✓ should startCluster with --sticky (3379ms)
    ✓ should startCluster with -p (3383ms)
    ✓ should startCluster with --cluster=2 (3391ms)
    ✓ should startCluster with --baseDir=root (3391ms)
    ✓ should startCluster with custom yadan framework (378ms)
    ✓ should startCluster with execArgv --inspect (3402ms)
    ✓ should support --require (3401ms)
    auto detect available port
      ✓ should auto detect available port (3390ms)

  test/lib/cmd/pkgfiles.test.js
    ✓ should update pkg.files (428ms)
    ✓ should check pkg.files (428ms)

  test/lib/cmd/test.test.js
    ✓ should success (635ms)
    ✓ should ignore node_modules and fixtures (621ms)
    ✓ should only test files specified by TESTS (560ms)
    ✓ should only test files specified by TESTS with multi pattern (570ms)
    ✓ should only test files specified by TESTS argv (561ms)
    ✓ should exit when not test files (331ms)
    ✓ should use process.env.TEST_REPORTER (648ms)
    ✓ should use process.env.TEST_TIMEOUT (637ms)
    ✓ should fail when test fail with power-assert (638ms)
    ✓ should warn when require intelli-espower-loader (643ms)
    ✓ should auto require test/.setup.js (1647ms)


  mocha-test
    ✓ should work


  1 passing (16ms)

    ✓ should force exit (630ms)
    simplify mocha error stack
      ✓ should clean assert error stack (634ms)
      ✓ should should show full stack trace (640ms)
      ✓ should clean co error stack (573ms)
      ✓ should clean callback error stack (579ms)
    changed
No changed test files
      ✓ should return undefined if no test file changed
      ✓ should return file changed
No changed test files
      ✓ should filter not test file

  test/mocha-bin.test.js


  mocha-test
    ✓ should work


  1 passing (5ms)

    ✓ should test with mocha (180ms)

  test/my-egg-bin.test.js
    ✓ should my-egg-bin test success (634ms)
    ✓ should my-egg-bin nsp success (306ms)
    ✓ should my-egg-bin dev success (374ms)
    ✓ should show help message (317ms)
    ✓ should show version 2.3.4 (298ms)
    3) should custom context
    ✓ should add no-timeouts at test when debug enabled (399ms)

  test/ts.test.js
    4) should support ts
    ✓ should support ts test (2076ms)
    real application
      5) should start app
      6) should test app
      7) should cov app
    error stacks
      8) should correct error stack line number in starting app
      ✓ should correct error stack line number in testing app (2009ms)
      ✓ should correct error stack line number in covering app (812ms)
    egg.typescript = true
      9) should start app
      10) should fail start app with --no-ts
      11) should start app with relative path
      12) should test app


  test/index.test.ts
    1) "before all" hook


  0 passing (325ms)
  1 failing

  1) test/index.test.ts
       "before all" hook:
     Error: Can not find plugin egg-onerror in "/home/alibaba/apsara/egg-bin/test/fixtures/example-ts-pkg/node_modules, /home/alibaba/apsara/egg-bin/node_modules/egg/node_modules, /home/alibaba/apsara/egg-bin/test/fixtures/example-ts-pkg/node_modules"
      at AgentWorkerLoader.getPluginPath (/home/alibaba/apsara/egg-bin/node_modules/egg-core/lib/loader/mixin/plugin.js:356:11)
      at AgentWorkerLoader.loadPlugin (/home/alibaba/apsara/egg-bin/node_modules/egg-core/lib/loader/mixin/plugin.js:108:26)
      at AgentWorkerLoader.loadConfig (/home/alibaba/apsara/egg-bin/node_modules/egg/lib/loader/agent_worker_loader.js:15:10)
      at new EggApplication (/home/alibaba/apsara/egg-bin/node_modules/egg/lib/egg.js:50:17)
      at new Agent (/home/alibaba/apsara/egg-bin/node_modules/egg/lib/agent.js:22:5)
      at MockApplication.[init] (/home/alibaba/apsara/egg-bin/node_modules/egg-mock/lib/app.js:63:33)
      at EventEmitter.next (<anonymous>)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
      [use `--full-trace` to display the full stack trace]




=============================== Coverage summary ===============================
Statements   : Unknown% ( 0/0 )
Branches     : Unknown% ( 0/0 )
Functions    : Unknown% ( 0/0 )
Lines        : Unknown% ( 0/0 )
================================================================================
