### PR TITLE
fix: ets not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test/fixtures/example-ts-ets/typings/
 *.log
 package-lock.json
 .nyc_output
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 env:
   - EGG_VERSION=1
   - EGG_VERSION=2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
     - nodejs_version: '8'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/bin/ets.js
+++ b/bin/ets.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+require('egg-ts-helper/dist/bin');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "bin": {
     "egg-bin": "bin/egg-bin.js",
-    "mocha": "bin/mocha.js"
+    "mocha": "bin/mocha.js",
+    "ets": "bin/ets.js"
   },
   "dependencies": {
     "autod": "^3.0.1",

--- a/test/ets-bin.test.js
+++ b/test/ets-bin.test.js
@@ -10,10 +10,9 @@ describe('test/ets-bin.test.js', () => {
   it('should test with ets', () => {
     return coffee.fork(etsBin, [], {
       cwd,
-      env: {
-        ...process.env,
+      env: Object.assign({}, process.env, {
         ETS_SILENT: 'false',
-      },
+      }),
     })
       // .debug()
       .expect('stdout', /\[egg-ts-helper\] create/)

--- a/test/ets-bin.test.js
+++ b/test/ets-bin.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require('path');
+const coffee = require('coffee');
+
+describe('test/ets-bin.test.js', () => {
+  const etsBin = require.resolve('../bin/ets.js');
+  const cwd = path.join(__dirname, 'fixtures/example-ts-ets');
+
+  it('should test with mocha', () => {
+    return coffee.fork(etsBin, [], {
+      cwd,
+      env: {
+        ...process.env,
+        ETS_SILENT: 'false',
+      },
+    })
+      // .debug()
+      .expect('stdout', /\[egg-ts-helper\] create/)
+      .expect('code', 0)
+      .end();
+  });
+});

--- a/test/ets-bin.test.js
+++ b/test/ets-bin.test.js
@@ -2,12 +2,19 @@
 
 const path = require('path');
 const coffee = require('coffee');
+const semver = require('semver');
 
 describe('test/ets-bin.test.js', () => {
   const etsBin = require.resolve('../bin/ets.js');
   const cwd = path.join(__dirname, 'fixtures/example-ts-ets');
 
   it('should test with ets', () => {
+    const higherVersion = semver.gte(process.version, '8.0.0');
+    if (!higherVersion) {
+      // skip 6.x, egg-ts-helper only works in >=8.0.0
+      return;
+    }
+
     return coffee.fork(etsBin, [], {
       cwd,
       env: Object.assign({}, process.env, {

--- a/test/ets-bin.test.js
+++ b/test/ets-bin.test.js
@@ -7,7 +7,7 @@ describe('test/ets-bin.test.js', () => {
   const etsBin = require.resolve('../bin/ets.js');
   const cwd = path.join(__dirname, 'fixtures/example-ts-ets');
 
-  it('should test with mocha', () => {
+  it('should test with ets', () => {
     return coffee.fork(etsBin, [], {
       cwd,
       env: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

egg-bin 中内置了 `egg-ts-helper`，一般情况下安装 egg-bin 后就不需要安装 `egg-ts-helper`，但是也导致缺少了对应的 bin：ets。所以在 egg-bin 中跟 mocha 一样补上对应的 bin 
