### PR TITLE
deps: bump ts-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "semver": "^5.5.0",
     "source-map-support": "^0.5.6",
     "test-exclude": "^5.0.0",
-    "ts-node": "^7.0.0",
+    "ts-node": "^8.0.3",
     "ypkgfiles": "^1.6.0"
   },
   "devDependencies": {

--- a/test/fixtures/example-ts-ets/node_modules/egg/index.js
+++ b/test/fixtures/example-ts-ets/node_modules/egg/index.js
@@ -2,7 +2,9 @@
 
 module.exports = require('../../../../../node_modules/egg');
 
-setTimeout(() => {
-  console.log('exit by master test end')
-  process.exit(0);
-}, require('os').platform() === 'win32' ? 10000 : 6000);
+if (process.execArgv.find(argv => argv.includes('egg-ts-helper'))) {
+  setTimeout(() => {
+    console.log('exit by master test end')
+    process.exit(0);
+  }, require('os').platform() === 'win32' ? 10000 : 6000);
+}

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -185,6 +185,7 @@ describe('test/ts.test.js', () => {
     it('should load egg-ts-helper with dts flag', () => {
       return coffee.fork(eggBin, [ 'dev', '--dts' ], { cwd })
         // .debug()
+        .expect('stdout', /application log/)
         .expect('stdout', /"typescript":true/)
         .expect('stdout', /started/)
         .expect('code', 0)
@@ -197,6 +198,7 @@ describe('test/ts.test.js', () => {
 
       return coffee.fork(eggBin, [ 'dev' ], { cwd })
         // .debug()
+        .expect('stdout', /application log/)
         .expect('stdout', /"typescript":true/)
         .expect('stdout', /"declarations":true/)
         .expect('stdout', /started/)
@@ -208,6 +210,7 @@ describe('test/ts.test.js', () => {
       return coffee.fork(eggBin, [ 'dev' ], { cwd })
         // .debug()
         .expect('stdout', /"typescript":true/)
+        .notExpect('stdout', /application log/)
         .notExpect('stdout', /"declarations":true/)
         .notExpect('stdout', /started/)
         .expect('code', 1)

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -185,7 +185,6 @@ describe('test/ts.test.js', () => {
     it('should load egg-ts-helper with dts flag', () => {
       return coffee.fork(eggBin, [ 'dev', '--dts' ], { cwd })
         // .debug()
-        .expect('stdout', /application log/)
         .expect('stdout', /"typescript":true/)
         .expect('stdout', /started/)
         .expect('code', 0)
@@ -198,7 +197,6 @@ describe('test/ts.test.js', () => {
 
       return coffee.fork(eggBin, [ 'dev' ], { cwd })
         // .debug()
-        .expect('stdout', /application log/)
         .expect('stdout', /"typescript":true/)
         .expect('stdout', /"declarations":true/)
         .expect('stdout', /started/)
@@ -210,7 +208,6 @@ describe('test/ts.test.js', () => {
       return coffee.fork(eggBin, [ 'dev' ], { cwd })
         // .debug()
         .expect('stdout', /"typescript":true/)
-        .notExpect('stdout', /application log/)
         .notExpect('stdout', /"declarations":true/)
         .notExpect('stdout', /started/)
         .expect('code', 1)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

升级一下 ts-node@8 ，里面的 break-change 主要在 bin 上 （ https://github.com/TypeStrong/ts-node/compare/v7.0.1...master ），对我们用 register 的没啥影响。

8.x 优化了错误信息展示，跟 tsc 的保持了一致，美观了很多

![image](https://user-images.githubusercontent.com/5856440/54577879-6b47c380-4a38-11e9-9392-1d4cbef2e455.png)

