### PR TITLE
fix: should not timeout when debugging

### DIFF
--- a/lib/cmd/debug.js
+++ b/lib/cmd/debug.js
@@ -69,7 +69,7 @@ class DebugCommand extends Command {
         proxy.start({ debugPort }).then(() => {
           // don't log within VSCode and WebStorm
           // TODO: don't start proxy within vscode and webstorm at next major
-          if (!process.env.VSCODE_CLI && !process.env.NODE_DEBUG_OPTION) {
+          if (!process.env.VSCODE_CLI && !process.env.NODE_DEBUG_OPTION && !process.env.JB_DEBUG_FILE) {
             console.log(chalk.yellow(`Debug Proxy online, now you could attach to ${proxyPort} without worry about reload.`));
             if (newDebugger) console.log(chalk.yellow(`DevTools → ${proxy.url}`));
           }

--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -74,7 +74,10 @@ class TestCommand extends Command {
    * @return {Array} [ '--require=xxx', 'xx.test.js' ]
    * @protected
    */
-  * formatTestArgs({ argv, debug }) {
+  * formatTestArgs({ argv, debugOptions }) {
+    // whether is debug mode, if pass --inspect then `debugOptions` is valid
+    // others like WebStorm 2019 will pass NODE_OPTIONS, and egg-bin itself will be debug, so could detect `process.debugPort`.
+    const isDebugging = debugOptions || process.debugPort;
     const testArgv = Object.assign({}, argv);
 
     /* istanbul ignore next */
@@ -83,7 +86,7 @@ class TestCommand extends Command {
     // force exit
     testArgv.exit = true;
 
-    if (debug) {
+    if (isDebugging) {
       // --no-timeouts
       testArgv.timeouts = false;
       testArgv.timeout = undefined;

--- a/test/lib/cmd/debug.test.js
+++ b/test/lib/cmd/debug.test.js
@@ -111,5 +111,16 @@ describe('test/lib/cmd/debug.test.js', () => {
         .expect('code', 0)
         .end();
     });
+
+    it('should not print devtools at webstorm 2019', function* () {
+      mm(process.env, 'JB_DEBUG_FILE', __filename);
+      const app = coffee.fork(eggBin, [ 'debug' ], { cwd });
+      // app.debug();
+      yield app.expect('stderr', /Debugger listening/)
+        .notExpect('stdout', /Debug Proxy online, now you could attach to 9999/)
+        .notExpect('stdout', /DevTools → chrome-devtools:.*:9999/)
+        .expect('code', 0)
+        .end();
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

修正之前的判断，在 Debug 的情况下，通知 mocha 不要 timeout