### PR TITLE
feat: update nyc to v15 and node to >=8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 env:
   - EGG_VERSION=1
   - EGG_VERSION=2
-matrix:
-  exclude:
-    - node_js: "6"
-      env: EGG_VERSION=2
 before_install:
   - npm install npminstall -g
 install:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jest-changed-files": "^24.7.0",
     "mocha": "^6.0.2",
     "mz-modules": "^2.1.0",
-    "nyc": "^13.3.0",
+    "nyc": "^15.1.0",
     "power-assert": "^1.6.1",
     "semver": "^6.0.0",
     "test-exclude": "^5.1.0",
@@ -72,7 +72,7 @@
     "autod": "node bin/egg-bin.js autod"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
   "files": [
     "index.js",
@@ -80,6 +80,6 @@
     "bin"
   ],
   "ci": {
-    "version": "6, 8"
+    "version": "8, 10"
   }
 }

--- a/test/lib/cmd/cov.test.js
+++ b/test/lib/cmd/cov.test.js
@@ -32,13 +32,13 @@ describe('test/lib/cmd/cov.test.js', () => {
       .notExpect('stdout', /a.js/);
 
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       child.expect('stdout', /Statements {3}: 80% \( 4[\/|\\]5 \)/);
     }
 
     yield child.expect('code', 0).end();
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) assertCoverage(cwd);
+    if (!process.env.NYC_CONFIG) assertCoverage(cwd);
   });
 
   it('should exit when not test files', done => {
@@ -62,13 +62,13 @@ describe('test/lib/cmd/cov.test.js', () => {
       .notExpect('stdout', /a.js/);
 
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       child.expect('stdout', /Statements {3}: 80% \( 4[\/|\\]5 \)/);
     }
 
     yield child.expect('code', 0).end();
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) assertCoverage(cwd);
+    if (!process.env.NYC_CONFIG) assertCoverage(cwd);
   });
 
   it('should success with COV_EXCLUDES', function* () {
@@ -82,13 +82,13 @@ describe('test/lib/cmd/cov.test.js', () => {
       .notExpect('stdout', /a.js/);
 
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       child.expect('stdout', /Statements {3}: 75% \( 3[\/|\\]4 \)/);
     }
 
     yield child.expect('code', 0).end();
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       assertCoverage(cwd);
       const lcov = fs.readFileSync(path.join(cwd, 'coverage/lcov.info'), 'utf8');
       assert(!/ignore[\/|\\]a.js/.test(lcov));
@@ -104,13 +104,13 @@ describe('test/lib/cmd/cov.test.js', () => {
       .notExpect('stdout', /a.js/);
 
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       child.expect('stdout', /Statements {3}: 75% \( 3[\/|\\]4 \)/);
     }
 
     yield child.expect('code', 0).end();
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       assertCoverage(cwd);
       const lcov = fs.readFileSync(path.join(cwd, 'coverage/lcov.info'), 'utf8');
       assert(!/ignore[\/|\\]a.js/.test(lcov));
@@ -126,13 +126,13 @@ describe('test/lib/cmd/cov.test.js', () => {
       .notExpect('stdout', /a.js/);
 
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       child.expect('stdout', /Statements {3}: 75% \( 3[\/|\\]4 \)/);
     }
 
     yield child.expect('code', 0).end();
     // only test on npm run test
-    if (!process.env.NYC_ROOT_ID) {
+    if (!process.env.NYC_CONFIG) {
       assertCoverage(cwd);
       const lcov = fs.readFileSync(path.join(cwd, 'coverage/lcov.info'), 'utf8');
       assert(!/ignore[\/|\\]a.js/.test(lcov));

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -70,7 +70,7 @@ describe('test/ts.test.js', () => {
         // .debug()
         .expect('stdout', /hi, egg, 123456/)
         .expect('stdout', /ts env: true/)
-        .expect('stdout', process.env.NYC_ROOT_ID ? /Coverage summary/ : /Statements.*100%/)
+        .expect('stdout', process.env.NYC_CONFIG ? /Coverage summary/ : /Statements.*100%/)
         .expect('code', 0)
         .end();
     });
@@ -79,7 +79,7 @@ describe('test/ts.test.js', () => {
       cwd = path.join(__dirname, './fixtures/example-ts-cluster');
       return coffee.fork(eggBin, [ 'cov', '--ts' ], { cwd })
         .debug()
-        .expect('stdout', process.env.NYC_ROOT_ID ? /Coverage summary/ : /Statements.*100%/)
+        .expect('stdout', process.env.NYC_CONFIG ? /Coverage summary/ : /Statements.*100%/)
         .expect('code', 0)
         .end();
     });
@@ -166,7 +166,7 @@ describe('test/ts.test.js', () => {
         // .debug()
         .expect('stdout', /hi, egg, 123456/)
         .expect('stdout', /ts env: true/)
-        .expect('stdout', process.env.NYC_ROOT_ID ? /Coverage summary/ : /Statements.*100%/)
+        .expect('stdout', process.env.NYC_CONFIG ? /Coverage summary/ : /Statements.*100%/)
         .expect('code', 0)
         .end();
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
since nyc removed `process.env.NYC_ROOT_ID`, `process.env.NYC_CONFIG` will be used to tell `cov mode` from `test mode`.
ref: nyc pr [#1078](https://github.com/istanbuljs/nyc/pull/1078/files)