### PR TITLE
fix: conflix source map support

### DIFF
--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -111,15 +111,12 @@ class TestCommand extends Command {
     if (requireArr.includes('intelli-espower-loader')) {
       console.warn('[egg-bin] don\'t need to manually require `intelli-espower-loader` anymore');
     } else if (testArgv.espower) {
-      requireArr.push(require.resolve('intelli-espower-loader'));
-    }
-
-    // for power-assert
-    if (testArgv.typescript && testArgv.espower) {
-      if (requireArr.includes(testArgv.tscompiler)) {
-        requireArr.splice(requireArr.indexOf(testArgv.tscompiler), 1);
+      if (testArgv.typescript) {
+        // espower-typescript must append after ts-node
+        requireArr.push(testArgv.tscompiler, require.resolve('../espower-typescript'));
+      } else {
+        requireArr.push(require.resolve('intelli-espower-loader'));
       }
-      requireArr.push(testArgv.tscompiler, require.resolve('../espower-typescript'));
     }
 
     testArgv.require = requireArr;

--- a/lib/espower-typescript.js
+++ b/lib/espower-typescript.js
@@ -8,8 +8,8 @@ const sourceCache = {};
 const cwd = process.cwd();
 
 espowerTypeScript({
-  pattern: path.resolve(cwd, 'test/**/*.@(ts|tsx)'),
-  extensions: [ 'ts', 'tsx' ],
+  pattern: path.resolve(cwd, 'test/**/*.@(js|jsx|ts|tsx)'),
+  extensions: [ 'js', 'jsx', 'ts', 'tsx' ],
 });
 
 function espowerTypeScript(options) {

--- a/test/fixtures/example-ts-error-stack-mixed/app.ts
+++ b/test/fixtures/example-ts-error-stack-mixed/app.ts
@@ -1,0 +1,9 @@
+export default function() {
+  // placeholder comments
+  // placeholder comments
+  // placeholder comments
+  // placeholder comments
+  if (process.env.THROW_ERROR === 'true') {
+    throw new Error('throw error');
+  }
+}

--- a/test/fixtures/example-ts-error-stack-mixed/config/config.default.ts
+++ b/test/fixtures/example-ts-error-stack-mixed/config/config.default.ts
@@ -1,0 +1,7 @@
+'use strict';
+
+export default () => {
+  const config = {} as any;
+  config.keys = '123456';
+  return config;
+};

--- a/test/fixtures/example-ts-error-stack-mixed/package.json
+++ b/test/fixtures/example-ts-error-stack-mixed/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "example-ts-error-stack",
+  "egg": {
+    "typescript": true
+  }
+}

--- a/test/fixtures/example-ts-error-stack-mixed/test/index.test.js
+++ b/test/fixtures/example-ts-error-stack-mixed/test/index.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('assert');
+
+describe('test/index.test.ts', () => {
+  // placeholder comments
+  it('should throw error', async () => {
+    throw new Error('error');
+  });
+
+  // placeholder comments
+  it('should assert', async () => {
+    const obj = { key: '111' };
+    assert(obj.key === '222');
+  });
+});

--- a/test/fixtures/example-ts-error-stack-mixed/tsconfig.json
+++ b/test/fixtures/example-ts-error-stack-mixed/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "strict": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "pretty": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "inlineSourceMap": true,
+    "importHelpers": true
+  },
+}

--- a/test/ts.test.js
+++ b/test/ts.test.js
@@ -160,6 +160,24 @@ describe('test/ts.test.js', () => {
         .expect('stdout', /Object\{key:"111"}/)
         .end();
     });
+
+    it('should correct error stack line number in mixed app', () => {
+      if (process.platform === 'win32') return;
+
+      const appDir = path.join(__dirname, './fixtures/example-ts-error-stack-mixed');
+      const testFile = path.resolve(appDir, 'test/index.test.js');
+      return coffee.fork(eggBin, [ 'test', testFile ], { cwd: appDir })
+        // .debug()
+        .expect('stdout', /error/)
+        .expect('stdout', /test[\/\\]{1}index\.test\.js:8:11\)/)
+        .expect('stdout', /test[\/\\]{1}index\.test\.js:14:5\)/)
+        .expect('stdout', /assert\(obj\.key === '222'\)/)
+        .expect('stdout', /| {3}| {3}|/)
+        .expect('stdout', /| {3}| {3}false/)
+        .expect('stdout', /| {3}"111"/)
+        .expect('stdout', /Object\{key:"111"}/)
+        .end();
+    });
   });
 
   describe('egg.typescript = true', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

##### Description of change
<!-- Provide a description of the change below this comment. -->

在 ts 项目下只注入 espower-typescript 就行（ intelli-espower-loader 中的 source-map-support 逻辑会使 espower-typescript 中的失效，导致堆栈行数异常 ），所以改成如果是 ts 项目就只注入 espower-typescript 。

为了保证在 espower-typescript 中 js 也能有 power-assert 的功能，并且能拿到对的堆栈行数，espower-typescript 中也加上 .js/.jsx 的处理
