### PR TITLE
fix: require tscompiler on current process

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -111,8 +111,14 @@ class Command extends BaseCommand {
     if (argv.typescript) {
       execArgvObj.require.push(argv.tscompiler);
 
+      // should require argv.tscompiler on current process, let it can require *.ts files
+      // e.g.: dev command will execute egg loader to find configs and plugins
+      require(argv.tscompiler);
       // tell egg loader to load ts file
+      // see https://github.com/eggjs/egg-core/blob/master/lib/loader/egg_loader.js#L443
       env.EGG_TYPESCRIPT = 'true';
+      // set current process.env.EGG_TYPESCRIPT too
+      process.env.EGG_TYPESCRIPT = 'true';
 
       // load files from tsconfig on startup
       env.TS_NODE_FILES = process.env.TS_NODE_FILES || 'true';


### PR DESCRIPTION
let current command process can require ts files

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
