### PR TITLE
fix: ignore ets when the current app don't has a framework dependencies

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -4,8 +4,9 @@ const path = require('path');
 const fs = require('fs');
 const runscript = require('runscript');
 
-// node posintall.js </path/to/egg-ts-helper/dist/bin>
+// node posintall.js </path/to/egg-ts-helper/dist/bin> <framework-package-name>
 const etsBinFile = process.argv[2] || require.resolve('egg-ts-helper/dist/bin');
+const frameworkPackageName = process.argv[3] || 'egg';
 
 // try to use INIT_CWD env https://docs.npmjs.com/cli/v9/commands/npm-run-script
 // npm_rootpath is npminstall
@@ -23,6 +24,8 @@ if (npmRunRoot) {
     // }
     if (pkg.eggModule) return;
     if (pkg.egg.isFramework) return;
+    // ignore when the current app don't has a framework dependencies
+    if (!pkg.dependencies || !pkg.dependencies[frameworkPackageName]) return;
     // set ETS_CWD
     process.env.ETS_CWD = npmRunRoot;
     console.log('[egg-bin:postinstall] run %s on %s', etsBinFile, npmRunRoot);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "coffee": "^5.4.0",
     "cross-env": "^3.1.3",
     "egg": "^3.9.1",
-    "egg-mock": "^5.8.3",
+    "egg-mock": "^5.10.2",
     "esbuild-register": "^2.5.0",
     "eslint": "^8.16.0",
     "eslint-config-egg": "^12.0.0",

--- a/test/ets-bin.test.js
+++ b/test/ets-bin.test.js
@@ -88,4 +88,21 @@ describe('test/ets-bin.test.js', () => {
       .expect('code', 0)
       .end();
   });
+
+  it('should test with postinstall ignore when missing egg deps', async () => {
+    const cwd = path.join(__dirname, 'fixtures/example-missing-egg-deps-ets');
+    await coffee.spawn('node', [ postinstallScript ], {
+      cwd,
+      env: {
+        ...process.env,
+        ETS_SILENT: 'false',
+        INIT_CWD: cwd,
+      },
+    })
+      .debug()
+      .notExpect('stdout', /\[egg-ts-helper\] create/)
+      .notExpect('stdout', /\[egg-bin:postinstall] run /)
+      .expect('code', 0)
+      .end();
+  });
 });

--- a/test/fixtures/example-egg-framework-ets/package.json
+++ b/test/fixtures/example-egg-framework-ets/package.json
@@ -1,8 +1,5 @@
 {
   "name": "example-egg-framework-ets",
-  "eggModule": {
-    "name": "foo"
-  },
   "egg": {
     "typescript": true,
     "isFramework": true

--- a/test/fixtures/example-missing-egg-deps-ets/package.json
+++ b/test/fixtures/example-missing-egg-deps-ets/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "example-missing-egg-deps-ets",
+  "egg": {
+    "typescript": true
+  },
+  "dependencies": {}
+}

--- a/test/fixtures/example-ts-ets/package.json
+++ b/test/fixtures/example-ts-ets/package.json
@@ -3,5 +3,8 @@
   "egg": {
     "typescript": true,
     "declarations": false
+  },
+  "dependencies": {
+    "egg": "*"
   }
 }

--- a/test/fixtures/test-demo-app/test/a.test.js
+++ b/test/fixtures/test-demo-app/test/a.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { app } = require('egg-mock/bootstrap');
 
 describe('a.test.js', () => {

--- a/test/lib/cmd/cov.test.js
+++ b/test/lib/cmd/cov.test.js
@@ -180,8 +180,6 @@ describe('test/lib/cmd/cov.test.js', () => {
   });
 
   it('test parallel', () => {
-    // FIXME: will timeout on macOS, ignore it
-    if (process.platform === 'darwin') return;
     mm(process.env, 'TESTS', 'test/**/*.test.js');
     return coffee.fork(eggBin, [ 'cov', '--parallel' ], {
       cwd: path.join(__dirname, '../../fixtures/test-demo-app'),

--- a/test/lib/cmd/cov.test.js
+++ b/test/lib/cmd/cov.test.js
@@ -180,6 +180,8 @@ describe('test/lib/cmd/cov.test.js', () => {
   });
 
   it('test parallel', () => {
+    // FIXME: will timeout on macOS, ignore it
+    if (process.platform === 'darwin') return;
     mm(process.env, 'TESTS', 'test/**/*.test.js');
     return coffee.fork(eggBin, [ 'cov', '--parallel' ], {
       cwd: path.join(__dirname, '../../fixtures/test-demo-app'),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
