### PR TITLE
fix: convert unhandled rejection to uncaught exception

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+test/fixtures

--- a/src/cmd/test.ts
+++ b/src/cmd/test.ts
@@ -107,7 +107,13 @@ export class TestCommand extends BaseCommand {
 
     const mochaArgs = await this.formatMochaArgs();
     if (!mochaArgs) return;
-    await this.forkNode(mochaFile, mochaArgs);
+    await this.forkNode(mochaFile, mochaArgs, {
+      execArgv: [
+        ...process.execArgv,
+        // https://github.com/mochajs/mocha/issues/2640#issuecomment-1663388547
+        '--unhandled-rejections=strict',
+      ],
+    });
   }
 
   protected async formatMochaArgs() {

--- a/test/cmd/test.test.ts
+++ b/test/cmd/test.test.ts
@@ -168,6 +168,14 @@ describe('test/cmd/test.test.ts', () => {
         .end();
     });
 
+    it('should success js', () => {
+      return coffee.fork(eggBin, [ 'test' ], { cwd: path.join(fixtures, 'test-unhandled-rejection') })
+        // .debug()
+        .expect('stdout', / Uncaught Error: mock error/)
+        .expect('code', 1)
+        .end();
+    });
+
     it('test parallel', () => {
       if (process.platform === 'win32') return;
       return coffee.fork(eggBin, [ 'test', '--parallel' ], {

--- a/test/fixtures/test-unhandled-rejection/package.json
+++ b/test/fixtures/test-unhandled-rejection/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-unhandled-rejection",
+  "files": [
+    "lib"
+  ]
+}

--- a/test/fixtures/test-unhandled-rejection/test/a.test.js
+++ b/test/fixtures/test-unhandled-rejection/test/a.test.js
@@ -1,0 +1,5 @@
+describe('a.test.js', () => {
+  it('should success', () => {
+    Promise.reject(new Error('mock error'));
+  });
+});


### PR DESCRIPTION
Mocha do not catch unhandled rejection by default. Case will faield until timeout. set `--unhandled-rejections` to strict, let case fail fast.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
