### PR TITLE
fix: convert unhandled rejection to uncaught exception (#235)

### DIFF
--- a/lib/cmd/test.js
+++ b/lib/cmd/test.js
@@ -90,7 +90,11 @@ class TestCommand extends Command {
       env: Object.assign({
         NODE_ENV: 'test',
       }, context.env),
-      execArgv: context.execArgv,
+      execArgv: [
+        ...context.execArgv,
+        // https://github.com/mochajs/mocha/issues/2640#issuecomment-1663388547
+        '--unhandled-rejections=strict',
+      ],
     };
     await this.helper.forkNode(mochaFile, testArgs, opt);
   }

--- a/test/fixtures/test-unhandled-rejection/package.json
+++ b/test/fixtures/test-unhandled-rejection/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-unhandled-rejection",
+  "files": [
+    "lib"
+  ]
+}

--- a/test/fixtures/test-unhandled-rejection/test/a.test.js
+++ b/test/fixtures/test-unhandled-rejection/test/a.test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('a.test.js', () => {
+  it('should success', () => {
+    Promise.reject(new Error('mock error'));
+  });
+});

--- a/test/lib/cmd/test.test.js
+++ b/test/lib/cmd/test.test.js
@@ -290,7 +290,7 @@ describe('test/lib/cmd/test.test.js', () => {
       // .debug()
       .expect('stdout', /env\.AUTO_AGENT: true/)
       .expect('stdout', /env\.ENABLE_MOCHA_PARALLEL: true/)
-      .expect('code', 0)
+      .expect('code', 0);
   });
 
   it('should failed with unhandled rejection', () => {

--- a/test/lib/cmd/test.test.js
+++ b/test/lib/cmd/test.test.js
@@ -291,6 +291,13 @@ describe('test/lib/cmd/test.test.js', () => {
       .expect('stdout', /env\.AUTO_AGENT: true/)
       .expect('stdout', /env\.ENABLE_MOCHA_PARALLEL: true/)
       .expect('code', 0)
+  });
+
+  it('should failed with unhandled rejection', () => {
+    return coffee.fork(eggBin, [ 'test' ], { cwd: path.join(__dirname, '../../fixtures/test-unhandled-rejection') })
+      .debug()
+      .expect('stdout', / Uncaught Error: mock error/)
+      .expect('code', 1)
       .end();
   });
 });


### PR DESCRIPTION
Mocha do not catch unhandled rejection by default. Case will faield until timeout. set `--unhandled-rejections` to strict, let case fail fast.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
