### PR TITLE
feat: supports retrieving the port from the configuration file (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ egg-bin dev
 #### dev options
 
 - `--framework` egg web framework root path.
-- `--port` server port, default to `7001`.
+- `--port` server port. If not specified, the port is obtained in the following order: [_egg.js_ configuration](https://www.eggjs.org/basics/config) `config/config.*.js` > `process.env.EGG_BIN_DEFAULT_PORT` > 7001 > other available ports.
 - `--workers` worker process number, default to `1` worker at local mode.
 - `--sticky` start a sticky cluster server, default to `false`.
 

--- a/src/cmd/dev.ts
+++ b/src/cmd/dev.ts
@@ -61,12 +61,15 @@ export class DevCommand extends BaseCommand {
     });
 
     if (!this.port) {
-      const configuration = utils.getConfig({
-        framework: this.framework,
-        baseDir: this.base,
-        env: 'local',
-      });
-      const configuredPort = configuration?.cluster?.listen?.port;
+      let configuredPort;
+      try {
+        const configuration = utils.getConfig({
+          framework: this.framework,
+          baseDir: this.base,
+          env: 'local',
+        });
+        configuredPort = configuration?.cluster?.listen?.port;
+      } catch (_) { /** skip when failing to read the configuration */ }
 
       if (configuredPort) {
         this.port = configuredPort;

--- a/test/cmd/dev.test.ts
+++ b/test/cmd/dev.test.ts
@@ -174,4 +174,16 @@ describe('test/cmd/dev.test.ts', () => {
         .end(done);
     });
   });
+
+  describe('obtain the port from config.*.js', () => {
+    const cwd = path.join(fixtures, 'example-port');
+    it('should obtain the port from config.default.js', () => {
+      coffee.fork(eggBin, [ 'dev' ], {
+        cwd,
+      })
+        .expect('stdout', /"port":6001/)
+        .expect('code', 0)
+        .end();
+    });
+  });
 });

--- a/test/fixtures/example-port/app/router.js
+++ b/test/fixtures/example-port/app/router.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/', ctx => {
+    ctx.body = 'hi, egg';
+  });
+};

--- a/test/fixtures/example-port/config/config.default.js
+++ b/test/fixtures/example-port/config/config.default.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.key = '12345';
+
+exports.cluster = {
+    listen: {
+        port: 6001,
+    },
+};

--- a/test/fixtures/example-port/package.json
+++ b/test/fixtures/example-port/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "example"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
- egg-bin

##### Description of change
<!-- Provide a description of the change below this comment. -->
Adjust the order in which ports are obtained：option `--port` > [_egg.js_ configuration](https://www.eggjs.org/basics/config) `config/config.*.js` > `process.env.EGG_BIN_DEFAULT_PORT` > 7001 > other available ports.

![image](https://github.com/eggjs/egg-bin/assets/35088591/ab8ffafd-c3f3-414b-a46e-a0a8fb897a17)

closes https://github.com/eggjs/egg-bin/issues/250