### PR TITLE
fix(dal-gen): await async loader.load() for egg4 compatibility

### DIFF
--- a/lib/dal-gen.js
+++ b/lib/dal-gen.js
@@ -23,7 +23,7 @@ const teggDalPkgName = process.argv[5];
       dalPkg: teggDalPkgName,
     });
     const loader = LoaderFactory.createLoader(moduleDir, 'MODULE');
-    const clazzList = loader.load();
+    const clazzList = await loader.load();
     for (const clazz of clazzList) {
       if (TableInfoUtil.getIsTable(clazz)) {
         const tableModel = TableModel.build(clazz);


### PR DESCRIPTION
## What

In egg4 the tegg loader's `load()` is async (returns a `Promise`), but `lib/dal-gen.js` consumed it synchronously:

```js
const clazzList = loader.load();
for (const clazz of clazzList) { ... }   // TypeError: clazzList is not iterable
```

So `egg-bin generate dal code <module>` fails with `clazzList is not iterable` against egg4 / `@eggjs/tegg@4`. Note `@eggjs/dal-runtime`'s own `DaoLoader` already awaits `.load()`.

## Fix

```js
const clazzList = await loader.load();
```

The call site is already inside an `async` IIFE, so this is safe. Targeting `5.x` since the `dal` command only exists on the 5.x line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)